### PR TITLE
Handle case where data source is not consulted

### DIFF
--- a/src/modules/iam-roles/main.tf
+++ b/src/modules/iam-roles/main.tf
@@ -37,7 +37,7 @@ locals {
   account_name      = lookup(module.always.descriptors, "account_name", module.always.stage)
   root_account_name = local.account_map.root_account_account_name
 
-  current_user_role_arn = coalesce(one(data.awsutils_caller_identity.current[*].eks_role_arn), one(data.awsutils_caller_identity.current[*].arn), "disabled")
+  current_user_role_arn = coalesce(one(data.awsutils_caller_identity.current[*].eks_role_arn), one(data.awsutils_caller_identity.current[*].arn), "arn:${local.account_map.aws_partition}:iam::000000000000:role/disabled")
 
   current_identity_account = local.dynamic_terraform_role_enabled ? split(":", local.current_user_role_arn)[4] : ""
 


### PR DESCRIPTION
## what

- Handle case where `data.awsutils_caller_identity` is `null` even though `local.dynamic_terraform_role_enabled` is `true`

## why

- When destroying components, Terraform does not always consult all the data sources, which can lead to unexpected null values. We experienced such a case, and the module threw an error trying to parse the backup value of `awsutils_caller_identity` (which was "disabled") because it does not have the right format of an ARN. This fix provides a better backup value.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
	- Updated the default behavior for role identification to return a consistent, well-formed identifier when a valid role isn’t provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->