### PR TITLE
chore(deps): restrict aws provider version to < 6.0.0

### DIFF
--- a/src/modules/team-assume-role-policy/versions.tf
+++ b/src/modules/team-assume-role-policy/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 4.9.0, < 6.0.0"
     }
   }
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 4.9.0, < 6.0.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This pull request includes a version constraint update for the AWS provider in the Terraform configuration file `src/versions.tf`. The change ensures compatibility with versions up to but not including 6.0.0.

* `src/versions.tf`: Updated the version constraint for the `aws` provider to `>= 4.9.0, < 6.0.0` to ensure compatibility with future versions while avoiding potential breaking changes in version 6.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS provider version constraints to allow versions >= 4.9.0 and < 6.0.0, preventing use of version 6.0.0 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->