### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/dynamic-roles.tf
+++ b/src/dynamic-roles.tf
@@ -63,10 +63,10 @@ locals {
     for k, v in yamldecode(data.utils_describe_stacks.teams[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
   } : local.empty
 
-  team_roles_vars = {
-    for k, v in local.team_roles_stacks :
-    k => v.components.terraform[var.team_roles_component_name].vars
-    if try(v.components.terraform[var.team_roles_component_name].vars, null) != null
+  team_vars = {
+    for k, v in local.teams_stacks :
+    k => v.components.terraform[var.teams_component_name].vars
+    if try(v.components.terraform[var.teams_component_name].vars, null) != null
   }
 
   teams_config = local.dynamic_role_enabled ? values(local.teams_vars)[0].teams_config : local.empty
@@ -77,7 +77,10 @@ locals {
     for k, v in yamldecode(data.utils_describe_stacks.team_roles[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
   } : local.empty
 
-  team_roles_vars = { for k, v in local.team_roles_stacks : k => v.components.terraform.aws-team-roles.vars if try(v.components.terraform.aws-team-roles.vars, null) != null }
+  team_roles_vars = { 
+    for k, v in local.team_roles_stacks : 
+    k => v.components.terraform[var.team_roles_compoent_name].vars 
+    if try(v.components.terraform[var.team_roles_component_name].vars, null) != null }
 
   all_team_vars = merge(local.teams_vars, local.team_roles_vars)
 

--- a/src/dynamic-roles.tf
+++ b/src/dynamic-roles.tf
@@ -63,7 +63,12 @@ locals {
     for k, v in yamldecode(data.utils_describe_stacks.teams[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
   } : local.empty
 
-  teams_vars   = { for k, v in local.teams_stacks : k => v.components.terraform.aws-teams.vars if try(v.components.terraform.aws-teams.vars, null) != null }
+  teams_vars = {
+    for k, v in local.teams_stacks :
+    k => v.components.terraform[var.teams_component_name].vars
+    if try(v.components.terraform[var.teams_component_name].vars, null) != null
+  }
+
   teams_config = local.dynamic_role_enabled ? values(local.teams_vars)[0].teams_config : local.empty
   team_names   = [for k, v in local.teams_config : k if try(v.enabled, true)]
   team_arns    = { for team_name in local.team_names : team_name => format(local.iam_role_arn_templates[local.account_role_map.identity], team_name) }

--- a/src/dynamic-roles.tf
+++ b/src/dynamic-roles.tf
@@ -21,7 +21,7 @@
 data "utils_describe_stacks" "teams" {
   count = local.dynamic_role_enabled ? 1 : 0
 
-  components      = ["aws-teams"]
+  components      = [var.teams_component_name]
   component_types = ["terraform"]
   sections        = ["vars"]
 }
@@ -29,7 +29,7 @@ data "utils_describe_stacks" "teams" {
 data "utils_describe_stacks" "team_roles" {
   count = local.dynamic_role_enabled ? 1 : 0
 
-  components      = ["aws-team-roles"]
+  components      = [var.team_roles_component_name]
   component_types = ["terraform"]
   sections        = ["vars"]
 }

--- a/src/dynamic-roles.tf
+++ b/src/dynamic-roles.tf
@@ -63,10 +63,10 @@ locals {
     for k, v in yamldecode(data.utils_describe_stacks.teams[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
   } : local.empty
 
-  teams_vars = {
-    for k, v in local.teams_stacks :
-    k => v.components.terraform[var.teams_component_name].vars
-    if try(v.components.terraform[var.teams_component_name].vars, null) != null
+  team_roles_vars = {
+    for k, v in local.team_roles_stacks :
+    k => v.components.terraform[var.team_roles_component_name].vars
+    if try(v.components.terraform[var.team_roles_component_name].vars, null) != null
   }
 
   teams_config = local.dynamic_role_enabled ? values(local.teams_vars)[0].teams_config : local.empty

--- a/src/dynamic-roles.tf
+++ b/src/dynamic-roles.tf
@@ -79,7 +79,7 @@ locals {
 
   team_roles_vars = { 
     for k, v in local.team_roles_stacks : 
-    k => v.components.terraform[var.team_roles_compoent_name].vars 
+    k => v.components.terraform[var.team_roles_component_name].vars 
     if try(v.components.terraform[var.team_roles_component_name].vars, null) != null }
 
   all_team_vars = merge(local.teams_vars, local.team_roles_vars)

--- a/src/modules/iam-roles/main.tf
+++ b/src/modules/iam-roles/main.tf
@@ -19,7 +19,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   privileged  = var.privileged
   tenant      = var.overridable_global_tenant_name
   environment = var.overridable_global_environment_name

--- a/src/modules/iam-roles/variables.tf
+++ b/src/modules/iam-roles/variables.tf
@@ -32,3 +32,9 @@ variable "overridable_global_stage_name" {
   description = "The stage name for the organization management account (where the `account-map` state is stored)"
   default     = "root"
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}

--- a/src/modules/roles-to-principals/main.tf
+++ b/src/modules/roles-to-principals/main.tf
@@ -12,7 +12,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   privileged  = var.privileged
   tenant      = var.overridable_global_tenant_name
   environment = var.overridable_global_environment_name

--- a/src/modules/roles-to-principals/variables.tf
+++ b/src/modules/roles-to-principals/variables.tf
@@ -60,3 +60,9 @@ variable "overridable_team_permission_sets_enabled" {
     EOT
   default     = true
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}

--- a/src/modules/team-assume-role-policy/github-assume-role-policy.mixin.tf
+++ b/src/modules/team-assume-role-policy/github-assume-role-policy.mixin.tf
@@ -76,7 +76,7 @@ module "github_oidc_provider" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "github-oidc-provider"
+  component   = var.github_oidc_provider_component_name
   environment = var.global_environment_name
 
   privileged = var.privileged

--- a/src/modules/team-assume-role-policy/variables.tf
+++ b/src/modules/team-assume-role-policy/variables.tf
@@ -52,3 +52,9 @@ variable "iam_users_enabled" {
   description = "True if you would like IAM Users to be able to assume the role."
   default     = false
 }
+
+variable "github_oidc_provider_component_name" {
+  type        = string
+  description = "The name of the github-oidc-provider component"
+  default     = "github-oidc-provider"
+}

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "accounts" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component  = "account"
+  component  = var.account_component_name
   privileged = true
 
   context = module.this.context

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -127,3 +127,15 @@ variable "account_component_name" {
   description = "The name of the account component"
   default     = "account"
 }
+
+variable "teams_component_name" {
+  type        = string
+  description = "The name of the teams component"
+  default     = "aws-teams"
+}
+
+variable "team_roles_component_name" {
+  type        = string
+  description = "The name of the team-roles component"
+  default     = "aws-team-roles"
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -121,3 +121,9 @@ variable "terraform_dynamic_role_enabled" {
   description = "If true, the IAM role Terraform will assume will depend on the identity of the user running terraform"
   default     = false
 }
+
+variable "account_component_name" {
+  type        = string
+  description = "The name of the account component"
+  default     = "account"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.
This update allows the codebase to adopt more standardized structure and naming practices.

## Changes in the top-level copmonent
* Defined the input variable `account_map_component_name`
* The variable defaults to preserving the behaviour of the current version.
* Remote state uses this variable to pull in the state of the components.

In addition, the following changes were made to replace hard-coded component names in `dynamic-roles.tf` with user-provided values:
* Defined the input variables `teams_component_name` and `team_roles_component_name`.
* The variables default to preserving the behaviour of the current version.
* The variables are used in `dynamic-roles.tf` instead of the hard-coded values.

## Changes made in the sub-modules:
* Replaced hard-coded component names with user-provided vlaues:
  * For sub-module `team-assume-role-policy`, defined variable `github_oidc_provider_component_name`.
  * For sub-module `roles-to-principals`, defined variable `account_map_component_name`.
  * For sub-module `iam-roles`, defined variable `account_map_component_name`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable variables to set component names (account, account-map, GitHub OIDC provider, teams, team-roles) so deployments can use custom component names.

* **Chores**
  * Updated modules and stack lookups to consume the new variables instead of hardcoded names, improving flexibility and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->