### PR TITLE
Support Github Environments for ODIC IAM assume policy

### DIFF
--- a/src/modules/team-assume-role-policy/github-assume-role-policy.mixin.tf
+++ b/src/modules/team-assume-role-policy/github-assume-role-policy.mixin.tf
@@ -33,7 +33,7 @@ locals {
     for r in local.trusted_github_repos_sub : (
       r["constraint"] == "" ?
       format("repo:%s/%s:*", coalesce(r["org"], var.trusted_github_org), r["repo"]) :
-      starts_with(r["constraint"], "ref:") || starts_with(r["constraint"], "environment:") ?
+      startswith(r["constraint"], "ref:") || startswith(r["constraint"], "environment:") ?
       format("repo:%s/%s:%s", coalesce(r["org"], var.trusted_github_org), r["repo"], r["constraint"]) :
       format("repo:%s/%s:ref:refs/heads/%s", coalesce(r["org"], var.trusted_github_org), r["repo"], r["constraint"])
     )


### PR DESCRIPTION
## what
* Support Github Environments for ODIC IAM assume policy

## why
* If GitHub workflow uses `environment`, then OIDC passes the environment in sub. Otherwise, it passes ref.

## References
* https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws#configuring-the-role-and-trust-policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for trusted GitHub repository constraints in team assume-role policies: accept explicit ref: and environment: constraint formats as well as plain branch names.
  * Maintains wildcard and default-branch behavior when no constraint is provided.
  * Backwards-compatible; no changes to exported interfaces or external data sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->