### PR TITLE
Update AWS provider version constraint

### DIFF
--- a/src/modules/team-assume-role-policy/versions.tf
+++ b/src/modules/team-assume-role-policy/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 6.0.0"
+      version = ">= 4.9.0"
     }
   }
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 6.0.0"
+      version = ">= 4.9.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This pull request updates the version constraints for the AWS provider in Terraform configuration files. The changes remove the upper version limit, allowing the use of newer AWS provider versions.

Terraform provider version constraints:

* [`src/modules/team-assume-role-policy/versions.tf`](diffhunk://#diff-2b9f00e90acbd295019b2928337944040dbf44f2fcff0025738a288989182b60L7-R7): Changed the AWS provider version constraint from `>= 4.9.0, < 6.0.0` to `>= 4.9.0`, removing the upper limit.
* [`src/versions.tf`](diffhunk://#diff-5442fd8f7ce5fc799c23e6e2f2d74be9d0abaffceb94e28de89fb166665b8dfaL7-R7): Updated the AWS provider version constraint in the same way, allowing versions greater than or equal to 4.9.0 without an upper bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility with newer AWS provider releases by removing the upper version bound in Terraform provider constraints across modules.
  * Maintains the existing minimum version requirement; no functional changes are expected for current users.
  * Eases upgrades and reduces version pinning conflicts, allowing adoption of future provider versions without immediate module updates.
  * Users upgrading to newer provider versions should review upstream provider release notes for any breaking changes before applying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->