### PR TITLE
Add account_map_defaults variable with default null

### DIFF
--- a/src/modules/roles-to-principals/main.tf
+++ b/src/modules/roles-to-principals/main.tf
@@ -19,6 +19,7 @@ module "account_map" {
   stage       = var.overridable_global_stage_name
 
   defaults = var.account_map_defaults
+  bypass   = var.account_map_bypass
 
   context = module.always.context
 }

--- a/src/modules/roles-to-principals/main.tf
+++ b/src/modules/roles-to-principals/main.tf
@@ -18,6 +18,8 @@ module "account_map" {
   environment = var.overridable_global_environment_name
   stage       = var.overridable_global_stage_name
 
+  defaults = var.account_map_defaults
+
   context = module.always.context
 }
 

--- a/src/modules/roles-to-principals/variables.tf
+++ b/src/modules/roles-to-principals/variables.tf
@@ -66,3 +66,9 @@ variable "account_map_defaults" {
   description = "Default values if the data source is empty"
   default     = null
 }
+
+variable "account_map_bypass" {
+  type        = bool
+  description = "Set to true to skip looking up the remote state and just return the defaults"
+  default     = false
+}

--- a/src/modules/roles-to-principals/variables.tf
+++ b/src/modules/roles-to-principals/variables.tf
@@ -60,3 +60,9 @@ variable "overridable_team_permission_sets_enabled" {
     EOT
   default     = true
 }
+
+variable "account_map_defaults" {
+  type        = any
+  description = "Default values if the data source is empty"
+  default     = null
+}

--- a/src/modules/team-assume-role-policy/main.tf
+++ b/src/modules/team-assume-role-policy/main.tf
@@ -55,7 +55,7 @@ module "denied_role_map" {
   permission_set_map = var.denied_permission_sets
 
   account_map_defaults = var.account_map_defaults
-  account_map_bypass = var.account_map_bypass
+  account_map_bypass   = var.account_map_bypass
 
   context = module.this.context
 }

--- a/src/modules/team-assume-role-policy/main.tf
+++ b/src/modules/team-assume-role-policy/main.tf
@@ -41,7 +41,7 @@ module "allowed_role_map" {
   permission_set_map = var.allowed_permission_sets
 
   account_map_defaults = var.account_map_defaults
-  account_map_bypass = var.account_map_bypass
+  account_map_bypass   = var.account_map_bypass
 
   context = module.this.context
 }

--- a/src/modules/team-assume-role-policy/main.tf
+++ b/src/modules/team-assume-role-policy/main.tf
@@ -40,6 +40,9 @@ module "allowed_role_map" {
   role_map           = var.allowed_roles
   permission_set_map = var.allowed_permission_sets
 
+  account_map_defaults = var.account_map_defaults
+  account_map_bypass = var.account_map_bypass
+
   context = module.this.context
 }
 
@@ -50,6 +53,9 @@ module "denied_role_map" {
   privileged         = var.privileged
   role_map           = var.denied_roles
   permission_set_map = var.denied_permission_sets
+
+  account_map_defaults = var.account_map_defaults
+  account_map_bypass = var.account_map_bypass
 
   context = module.this.context
 }

--- a/src/modules/team-assume-role-policy/variables.tf
+++ b/src/modules/team-assume-role-policy/variables.tf
@@ -52,3 +52,15 @@ variable "iam_users_enabled" {
   description = "True if you would like IAM Users to be able to assume the role."
   default     = false
 }
+
+variable "account_map_defaults" {
+  type        = any
+  description = "Default values if the data source is empty"
+  default     = null
+}
+
+variable "account_map_bypass" {
+  type        = bool
+  description = "Set to true to skip looking up the remote state and just return the defaults"
+  default     = false
+}


### PR DESCRIPTION
## what
* Add account_map_defaults variable with default null

## why
* Migrate to account-map deprication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration options to customize account mapping behavior, enabling default values for empty data sources and the ability to bypass remote state lookups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->