### PR TITLE
Add bypass variable to iam-roles sub-module

### DIFF
--- a/src/modules/iam-roles/README.md
+++ b/src/modules/iam-roles/README.md
@@ -15,7 +15,6 @@ at all).
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -49,6 +48,7 @@ at all).
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_bypass"></a> [bypass](#input\_bypass) | Skip the account-map lookup and return safe defaults. Use when the caller does not need dynamic role resolution (e.g., legacy accounts that authenticate via environment credentials). | `bool` | `false` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>  format = string<br/>  labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
@@ -92,6 +92,4 @@ at all).
 | <a name="output_terraform_profile_name"></a> [terraform\_profile\_name](#output\_terraform\_profile\_name) | The AWS config profile name for Terraform to use when provisioning resources in the account, when profiles are in use |
 | <a name="output_terraform_role_arn"></a> [terraform\_role\_arn](#output\_terraform\_role\_arn) | The AWS Role ARN for Terraform to use when provisioning resources in the account, when Role ARNs are in use |
 | <a name="output_terraform_role_arns"></a> [terraform\_role\_arns](#output\_terraform\_role\_arns) | All of the terraform role arns |
-<!-- markdownlint-restore -->
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-

--- a/src/modules/iam-roles/outputs.tf
+++ b/src/modules/iam-roles/outputs.tf
@@ -1,25 +1,25 @@
 output "terraform_role_arn" {
-  value       = local.profiles_enabled ? null : local.final_terraform_role_arns[local.account_name]
+  value       = var.bypass ? null : (local.profiles_enabled ? null : local.final_terraform_role_arns[local.account_name])
   description = "The AWS Role ARN for Terraform to use when provisioning resources in the account, when Role ARNs are in use"
 }
 
 output "terraform_role_arns" {
-  value       = local.account_map.terraform_roles
+  value       = var.bypass ? {} : local.account_map.terraform_roles
   description = "All of the terraform role arns"
 }
 
 output "terraform_profile_name" {
-  value       = local.profiles_enabled ? local.account_map.profiles[local.account_name] : null
+  value       = var.bypass ? null : (local.profiles_enabled ? local.account_map.profiles[local.account_name] : null)
   description = "The AWS config profile name for Terraform to use when provisioning resources in the account, when profiles are in use"
 }
 
 output "aws_partition" {
-  value       = local.account_map.aws_partition
+  value       = var.bypass ? "aws" : local.account_map.aws_partition
   description = "The AWS \"partition\" to use when constructing resource ARNs"
 }
 
 output "org_role_arn" {
-  value       = local.account_org_role_arns[local.account_name]
+  value       = var.bypass ? null : local.account_org_role_arns[local.account_name]
   description = "The AWS Role ARN for Terraform to use when SuperAdmin is provisioning resources in the account"
 }
 
@@ -47,37 +47,37 @@ output "current_account_account_name" {
 }
 
 output "dns_terraform_role_arn" {
-  value       = local.profiles_enabled ? null : local.final_terraform_role_arns[local.account_map.dns_account_account_name]
+  value       = var.bypass ? null : (local.profiles_enabled ? null : local.final_terraform_role_arns[local.account_map.dns_account_account_name])
   description = "The AWS Role ARN for Terraform to use to provision DNS Zone delegations, when Role ARNs are in use"
 }
 
 output "dns_terraform_profile_name" {
-  value       = local.profiles_enabled ? local.account_map.terraform_profiles[local.account_map.dns_account_account_name] : null
+  value       = var.bypass ? null : (local.profiles_enabled ? local.account_map.terraform_profiles[local.account_map.dns_account_account_name] : null)
   description = "The AWS config profile name for Terraform to use to provision DNS Zone delegations, when profiles are in use"
 }
 
 output "audit_terraform_role_arn" {
-  value       = local.profiles_enabled ? null : local.final_terraform_role_arns[local.account_map.audit_account_account_name]
+  value       = var.bypass ? null : (local.profiles_enabled ? null : local.final_terraform_role_arns[local.account_map.audit_account_account_name])
   description = "The AWS Role ARN for Terraform to use to provision resources in the \"audit\" role account, when Role ARNs are in use"
 }
 
 output "audit_terraform_profile_name" {
-  value       = local.profiles_enabled ? local.account_map.terraform_profiles[local.account_map.audit_account_account_name] : null
+  value       = var.bypass ? null : (local.profiles_enabled ? local.account_map.terraform_profiles[local.account_map.audit_account_account_name] : null)
   description = "The AWS config profile name for Terraform to use to provision resources in the \"audit\" role account, when profiles are in use"
 }
 
 output "identity_account_account_name" {
-  value       = local.account_map.identity_account_account_name
+  value       = var.bypass ? "" : local.account_map.identity_account_account_name
   description = "The account name (usually `<tenant>-<stage>`) for the account holding primary IAM roles"
 }
 
 output "identity_terraform_role_arn" {
-  value       = local.profiles_enabled ? null : local.final_terraform_role_arns[local.account_map.identity_account_account_name]
+  value       = var.bypass ? null : (local.profiles_enabled ? null : local.final_terraform_role_arns[local.account_map.identity_account_account_name])
   description = "The AWS Role ARN for Terraform to use to provision resources in the \"identity\" role account, when Role ARNs are in use"
 }
 
 output "identity_terraform_profile_name" {
-  value       = local.profiles_enabled ? local.account_map.terraform_profiles[local.account_map.identity_account_account_name] : null
+  value       = var.bypass ? null : (local.profiles_enabled ? local.account_map.terraform_profiles[local.account_map.identity_account_account_name] : null)
   description = "The AWS config profile name for Terraform to use to provision resources in the \"identity\" role account, when profiles are in use"
 }
 

--- a/src/modules/iam-roles/variables.tf
+++ b/src/modules/iam-roles/variables.tf
@@ -1,3 +1,9 @@
+variable "bypass" {
+  type        = bool
+  description = "Skip the account-map lookup and return safe defaults. Use when the caller does not need dynamic role resolution (e.g., legacy accounts that authenticate via environment credentials)."
+  default     = false
+}
+
 variable "privileged" {
   type        = bool
   description = "True if the Terraform user already has access to the backend"


### PR DESCRIPTION
## What

Adds a `bypass` variable to the `iam-roles` sub-module that skips the account-map remote-state lookup and returns safe defaults (null/empty values).

## Why

Components that are shared across both account-map-enabled and non-account-map-enabled stacks need a way to conditionally disable the iam-roles module's remote-state dependency. The `bypass` flag allows the calling component to pass through its own `account_map_enabled` setting, e.g.:

```hcl
module "iam_roles" {
  source  = "../account-map/modules/iam-roles"
  bypass  = !var.account_map_enabled
  context = module.this.context
}
```

When `bypass = true`, all outputs return safe defaults (null ARNs, empty maps) and no remote-state or provider lookups are attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bypass flag to the IAM roles module that disables dynamic role resolution and uses safe defaults instead.
  * When enabled, bypasses account lookups, role assumptions, and profile-based provisioning, returning null or empty values for affected outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->