### PR TITLE
chore: widen cloudposse/utils provider to < 3.0.0

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.10.0"
+      version = ">= 1.10.0, < 3.0.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `< 3.0.0` upper bound to `cloudposse/utils` provider (was unbounded at `>= 1.10.0`)
- Establishes a consistent upper bound across all EKS components

## Test plan
- [ ] Verify `terraform init` succeeds with the updated constraint
- [ ] Verify `terraform plan` produces no unexpected changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)